### PR TITLE
feature:node details metrics

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -18,6 +18,7 @@
     "aliveness_vhost": "/",
     "enabled_exporters": [
             "exchange",
+            "connections",
             "node",
             "overview",
             "queue",


### PR DESCRIPTION
通过为queue的exporter增加node label，可以直接使用prometheus查询语句来获取node节点上queue/message/consumers的监控数据
node queue数量：
count(rabbitmq_queue_state{node="rabbit@rabbit37-1"})
count(rabbitmq_queue_state{node="rabbit@rabbit37-2"})
count(rabbitmq_queue_state{node="rabbit@rabbit37-3"})

node consumers数量：
sum(rabbitmq_queue_consumers{node="rabbit@rabbit37-1"})
sum(rabbitmq_queue_consumers{node="rabbit@rabbit37-2"})
sum(rabbitmq_queue_consumers{node="rabbit@rabbit37-3"})


node message_total数量
sum(rabbitmq_queue_messages{node="rabbit@rabbit37-1"})
sum(rabbitmq_queue_messages{node="rabbit@rabbit37-2"})
sum(rabbitmq_queue_messages{node="rabbit@rabbit37-3"})

node connections 数量
sum(rabbitmq_connection_channels{node="rabbit@rabbit37-1"})
sum(rabbitmq_connection_channels{node="rabbit@rabbit37-2"})
sum(rabbitmq_connection_channels{node="rabbit@rabbit37-3"})